### PR TITLE
Add custom list management support

### DIFF
--- a/resources/lists/Custom/sample_custom.txt
+++ b/resources/lists/Custom/sample_custom.txt
@@ -1,0 +1,3 @@
+alpha
+beta
+gamma


### PR DESCRIPTION
## Summary
- enable selecting and editing custom lists in ListSelectionDialog
- implement `manageCustomLists` to launch custom list dialogs
- handle creating/applying custom lists through `handleListSelection`
- dispatch from menu to appropriate list managers
- add example custom list file

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68404be163308330bd0e07168ed7657f