### PR TITLE
Implement keyword emphasis in preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ nGrams Analysis: Identify common phrases and themes with bigrams and trigrams vi
 Readability Metrics: Tailor your content with readability scores to reach your desired audience.
 Named Entity Recognition: Discover key entities such as people, places, and organizations in your text.
 Customizable Lists: Refine your analysis with purpose-built lists, including regional vernacular and domain-specific terms.
+Key Word Emphasis: Highlight selected key words in the processed text by converting them to uppercase.
 Why Book Worm NLP?
 We're here to demystify text analysis, offering a bridge between you and the deeper meanings in your data. With Book Worm NLP, every word counts towards a greater understanding.
 

--- a/controller.py
+++ b/controller.py
@@ -30,16 +30,16 @@ class NLPToolkitController:
         # Assuming `lemmatize_text_content` is a function you've defined that takes a string and returns a list of lemmatized words
         text = ' '.join(self.lemmatize_text_content(text))
 
-        # Optionally emphasize key words if enabled
-        # This part depends on how you want to emphasize key words - this is a placeholder for the logic
+        # Optionally emphasize key words if enabled.  The chosen
+        # emphasis style is to convert matching words to upper case so
+        # they stand out in the processed output without introducing
+        # additional markup characters.
         if self.use_key_words and self.key_words_list:
-            emphasized_text = []
-            for word in text.split():
-                if word.lower() in [kw.lower() for kw in self.key_words_list]:
-                    # This is a placeholder for emphasis, e.g., making the word uppercase or appending a tag
-                    emphasized_text.append(word.upper())  # Example: emphasize by making uppercase
-                else:
-                    emphasized_text.append(word)
+            key_words = {kw.lower() for kw in self.key_words_list}
+            emphasized_text = [
+                word.upper() if word.lower() in key_words else word
+                for word in text.split()
+            ]
             text = ' '.join(emphasized_text)
 
         print(f"Preprocessed text: {text}")


### PR DESCRIPTION
## Summary
- finalize keyword emphasis in `NLPToolkitController.preprocess_text`
- document keyword emphasis option in README

## Testing
- `python -m py_compile controller.py preprocessing.py features.py ui.py main.py glossary_html.py faq_html.py welcome_html.py nltk_download.py style_sheets.py`

------
https://chatgpt.com/codex/tasks/task_e_68404be57d488330b69846e0a9dcdef4